### PR TITLE
Update OWM_EPD47_epaper_v2.5.ino

### DIFF
--- a/OWM_EPD47_epaper_v2.5.ino
+++ b/OWM_EPD47_epaper_v2.5.ino
@@ -594,6 +594,8 @@ void DisplayConditionsSection(int x, int y, String IconName, bool IconSize) {
 }
 
 void arrow(int x, int y, int asize, float aangle, int pwidth, int plength) {
+  aangle = aangle +180;
+  if (aangle >=360){aangle = aangle -360;}
   float dx = (asize - 10) * cos((aangle - 90) * PI / 180) + x; // calculate X position
   float dy = (asize - 10) * sin((aangle - 90) * PI / 180) + y; // calculate Y position
   float x1 = 0;         float y1 = plength;


### PR DESCRIPTION
Great project but I discovered that the Wind Direction Arrow did not match a physical Weather Vane system I made that also derives its data from Openweather. So if the wind is coming from the East the Weather Vane points West, I just wondered if it makes more sense for the Arrow on the display to do the same rather than point in the direction the Wind is coming from, which is displayed anyway in the circle.

I'm sure you can do this in a much more elegant way, but hopefully it provides a demonstration of the concept.

I did also add a Picture (Hex Art created from a JPEG) to my version next to the current weather symbol but its just for decoration - but fills the space quite nicely. 